### PR TITLE
Updating PIO information in users guide.

### DIFF
--- a/users_guide/shared/mpas_build_instructions.tex
+++ b/users_guide/shared/mpas_build_instructions.tex
@@ -12,6 +12,8 @@ An MPI installation such as MPICH or OpenMPI is also required, and there is no o
 \section{Compiling I/O Libraries}
 \label{sec:build_io}
 
+{\bf NOTE:} It's important to note the MPAS Developers are not responsible for any of the libraries that are used within MPAS. Support for specific libraries should be taken up with the respective developer groups.
+
 Although most recent versions of the I/O libraries should work, the most tested versions of these libraries are: netCDF 4.1.3, parallel-netCDF 1.3.0, and PIO 1.4.1. The netCDF and parallel-netCDF libraries must be installed before building PIO library.
 
 \subsection{netCDF}
@@ -72,13 +74,18 @@ document, so please refer to them if you run into any issues.
 
 Due to the rapid development pace of PIO, the preferred method of obtaining the PIO library is via subversion checkout. The PIO repository URL
 can be found at \url{http://code.google.com/p/parallelio/}.
+
+It is recommended users begin trying to use the current trunk of the subversion repository. However, the latest version is not always tested within MPAS. The lateset version that has been tested within MPAS at the time of writing this is 1.6.8.
+
 Assuming that all environment variables mentioned in the preceding sections are
 still set (including {\tt NETCDF\_PATH} and {\tt PNETCDF\_PATH}), the following
 shell commands are generally sufficient to build the PIO library; there is no
 separate installation step for PIO.
 
 \vspace{12pt}
-{\tt > svn co http://parallelio.googlecode.com/svn/trunk/pio PIO}
+{trunk\tt > svn co http://parallelio.googlecode.com/svn/trunk/pio pio-trunk}
+
+{v1.6.8\tt > svn co http://parallelio.googlecode.com/svn/trunk\_tags/pio1\_6\_8 pio-1.6.8}
 
 {\tt > ./configure}
 


### PR DESCRIPTION
Pointing users to use the v1.6.8 tag of PIO if the current trunk doesn't
work.

Also adding a note about support for external libraries.
