### PR TITLE
Adding a description of the land_ice_fluxes namelist

### DIFF
--- a/users_guide/ocean/mode_forward_sections.tex
+++ b/users_guide/ocean/mode_forward_sections.tex
@@ -617,6 +617,12 @@ Embedded links point to more detailed namelist information in the appendix.
 \end{longtable}
 \end{center}
 }
+\subsection[land\_ice\_fluxes]{land\_ice\_fluxes}
+\label{subsec:forward_nm_tab_land_ice_fluxes}
+\input{ocean/section_descriptions/land_ice_fluxes.tex}
+\vspace{0.5in}
+{\small
+}
 \subsection[advection]{advection}
 \label{subsec:forward_nm_tab_advection}
 \input{ocean/section_descriptions/advection.tex}

--- a/users_guide/ocean/mpas_ocean.bib
+++ b/users_guide/ocean/mpas_ocean.bib
@@ -478,3 +478,97 @@ pages = {1--52}
   year={2013},
   publisher={Elsevier}
 }
+
+%%% land ice fluxes %%%
+@article{Holland1999,
+author = {Holland, David M. and Jenkins, Adrian},
+file = {:home/xylar/Documents/Mendeley/Holland, Jenkins - 1999 - Modeling Thermodynamic Ice–Ocean Interactions at the Base of an Ice Shelf.pdf:pdf},
+issn = {0022-3670},
+journal = {Journal of Physical Oceanography},
+mendeley-groups = {ice/ocean interactions/modeling,SciDAC,SciDAC/boundary layer,popsicle - GMD},
+month = aug,
+number = {8},
+pages = {1787--1800},
+title = {{Modeling Thermodynamic Ice–Ocean Interactions at the Base of an Ice Shelf}},
+url = {http://journals.ametsoc.org/doi/abs/10.1175/1520-0485(1999)029<1787:MTIOIA>2.0.CO;2},
+volume = {29},
+year = {1999}
+}
+
+@article{Jenkins2010,
+author = {Jenkins, Adrian and Nicholls, Keith W. and Corr, Hugh F. J.},
+doi = {10.1175/2010JPO4317.1},
+file = {:home/xylar/Documents/Mendeley/Jenkins, Nicholls, Corr - 2010 - Observation and Parameterization of Ablation at the Base of Ronne Ice Shelf, Antarctica.pdf:pdf},
+issn = {0022-3670},
+journal = {Journal of Physical Oceanography},
+mendeley-groups = {ice/ocean interactions/science,SciDAC,SciDAC/boundary layer,SciDAC/observations},
+month = oct,
+number = {10},
+pages = {2298--2312},
+title = {{Observation and Parameterization of Ablation at the Base of Ronne Ice Shelf, Antarctica}},
+url = {http://journals.ametsoc.org/doi/abs/10.1175/2010JPO4317.1},
+volume = {40},
+year = {2010}
+}
+
+@article{Goldberg2012a,
+author = {Goldberg, D. N. and Little, C. M. and Sergienko, O. V. and Gnanadesikan, A. and Hallberg, R. and Oppenheimer, M.},
+doi = {10.1029/2011JF002247},
+file = {:home/xylar/Documents/Mendeley/Goldberg et al. - 2012 - Investigation of land ice-ocean interaction with a fully coupled ice-ocean model 2. Sensitivity to external for.pdf:pdf},
+issn = {0148-0227},
+journal = {Journal of Geophysical Research},
+keywords = {buttressing,grounding line,ice shelf melting,ice-ocean coupling},
+mendeley-groups = {ice/ocean interactions/modeling,SciDAC,SciDAC/coupled modeling,popsicle - GMD},
+month = jun,
+number = {F2},
+pages = {1--11},
+title = {{Investigation of land ice-ocean interaction with a fully coupled ice-ocean model: 2. Sensitivity to external forcings}},
+url = {http://www.agu.org/pubs/crossref/2012/2011JF002247.shtml},
+volume = {117},
+year = {2012}
+}
+
+@article{Goldberg2012,
+author = {Goldberg, D. N. and Little, C. M. and Sergienko, O. V. and Gnanadesikan, A. and Hallberg, R. and Oppenheimer, M.},
+doi = {10.1029/2011JF002246},
+file = {:home/xylar/Documents/Mendeley/Goldberg et al. - 2012 - Investigation of land ice-ocean interaction with a fully coupled ice-ocean model 1. Model description and behav.pdf:pdf},
+issn = {0148-0227},
+journal = {Journal of Geophysical Research},
+keywords = {Ice streams,buttressing,grounding line,ice shelf melting,ice shelves,ice-ocean coupling},
+mendeley-groups = {ice/ocean interactions/modeling,SciDAC,SciDAC/coupled modeling,popsicle - GMD},
+month = jun,
+number = {F2},
+pages = {1--16},
+title = {{Investigation of land ice-ocean interaction with a fully coupled ice-ocean model: 1. Model description and behavior}},
+url = {http://www.agu.org/pubs/crossref/2012/2011JF002246.shtml},
+volume = {117},
+year = {2012}
+}
+
+@techreport{Hunter2006,
+author = {Hunter, JR},
+file = {:home/xylar/Documents/Mendeley/Hunter - 2006 - Specification for test models of ice shelf cavities.pdf:pdf},
+institution = {Antarctic Climate \& Ecosystems Cooperative Research Centre Private},
+mendeley-groups = {ice/ocean interactions/modeling,popsicle - GMD},
+number = {June},
+pages = {1--17},
+title = {{Specification for test models of ice shelf cavities}},
+url = {http://staff.acecrc.org.au/~johunter/isomip/test\_cavities.pdf},
+year = {2006}
+}
+
+@article{Jenkins2001,
+author = {Jenkins, Adrian and Hellmer, Hartmut H. and Holland, David M.},
+doi = {10.1175/1520-0485(2001)031<0285:TROMAI>2.0.CO;2},
+file = {:home/xylar/Documents/Mendeley/Jenkins, Hellmer, Holland - 2001 - The Role of Meltwater Advection in the Formulation of Conservative Boundary Conditions at an Ice–Oc.pdf:pdf},
+issn = {0022-3670},
+journal = {Journal of Physical Oceanography},
+mendeley-groups = {ice/ocean interactions/modeling,SciDAC,SciDAC/boundary layer,SciDAC/ice ocean processes,popsicle - GMD},
+month = jan,
+number = {1},
+pages = {285--296},
+title = {{The Role of Meltwater Advection in the Formulation of Conservative Boundary Conditions at an Ice–Ocean Interface}},
+url = {http://journals.ametsoc.org/doi/abs/10.1175/1520-0485(2001)031<0285:TROMAI>2.0.CO;2 http://journals.ametsoc.org/doi/abs/10.1175/1520-0485\%282001\%29031\%3C0285\%3ATROMAI\%3E2.0.CO\%3B2},
+volume = {31},
+year = {2001}
+}

--- a/users_guide/ocean/section_descriptions/forcing.tex
+++ b/users_guide/ocean/section_descriptions/forcing.tex
@@ -1,6 +1,6 @@
 Forcing may be applied to the RHS of the momentum equation (\ref{ocean:momentum}) through the term 
 \begin{equation}
-{\cal F}^u = \frac{1}{\rho_0 h}\tau
+{\cal F}^u = \frac{1}{\rho_0 h}\tau \label{ocean:\mode_mom_surf_forcing}
 \end{equation}
 where $\tau$ is typically the wind stress in $N/m^2$ applied to the top layer.  More generally, momentum forcing may be applied to any layer in the ocean.  The momentum forcing may be constant or monthly, as described in the configuration settings below.  When running within the CESM, the wind stress is provided by the coupler (see Chapter \ref{chap:cesm_ocean_coupling}).
 

--- a/users_guide/ocean/section_descriptions/land_ice_fluxes.tex
+++ b/users_guide/ocean/section_descriptions/land_ice_fluxes.tex
@@ -1,0 +1,102 @@
+MPAS-Ocean supports the option to compute fluxes across 
+the land ice-ocean interface in either ``standalone'' or ``coupled''
+mode.  
+
+In either mode, quadratic top drag is applied as a surface stress 
+in (\ref{ocean:\mode_mom_surf_forcing}), where
+\begin{align}
+\tau = & \rho_0 C_\textrm{D,top} \overline{\left(|u| u\right)}^\textrm{BL},
+\end{align}
+and where $C_\textrm{D,top}$ is the dimensionless top drag coefficient
+and the operator $\overline{\left(\cdot\right)}^\textrm{BL}$ indicates 
+the vertical average over the boundary layer below land ice, which
+has a depth $H_\textrm{BL}$.  Several additional diagnostics are computed
+in either mode:
+\begin{align}
+u_* = & \sqrt{C_\textrm{D,top} \overline{\left(|u|^2+u_\textrm{tidal}^2\right)}^\textrm{BL}}, \\
+\Theta_\textrm{BL} = & \overline{\left(\Theta\right)}^\textrm{BL}, \\
+S_\textrm{BL} = & \overline{\left(S\right)}^\textrm{BL}.
+\end{align}
+
+The boundary conditions at the ice-ocean interface arise
+from conservation of enthalpy and salt across the interface and the requirement that the interface
+be at the pressure- and salinity-dependent potential freezing point:
+\begin{align}
+   \rho_\textrm{fw} L m_w & = \mathcal{F}_\textrm{H,ice} - \rho_\textrm{sw} c_p \gamma_\Theta \left(\Theta_b - \Theta_\textrm{BL} \right), \label{ocean:\mode_land_ice_enthalpy_balance}\\
+   \rho_\textrm{fw} m_w S_b & = - \rho_\textrm{sw} \gamma_S \left(S_b - S_\textrm{BL}\right),  \\
+   \Theta_b & = \Theta_f(S,p), \\
+\end{align}
+where $\rho_\textrm{fw}$ is the density of freshwater, $L$ is the latent heat of fusion of
+water, $\mathcal{F}_\textrm{H,ice}$ is the sensible heat flux into the ice (always negative),
+$\rho_\textrm{sw}$ is the reference denstiy of seawater $c_p$ is the heat capacity of seawater
+$\gamma_\Theta$ and $\gamma_S$ are thermal- and salt-transfer velocities,
+$\Theta_f$ is the freezing potential temperature and $\Theta_b$, $S_b$ and $m_w$ are the
+unknown potential temperature and salinity at the boundary and the melt rate (expressed in 
+water-equivalent).  The associated surface freshwater, heat and salt fluxes are
+\begin{align}
+   \mathcal{F}_\textrm{fw} & = \rho_\textrm{fw} m_w, \\
+   \mathcal{F}_\textrm{H} & = c_p \left[F_\textrm{fw} \Theta_b + \rho_\textrm{sw} \gamma_\Theta \left(\Theta_b - \Theta_\textrm{BL}\right)\right], \\
+   \mathcal{F}_\textrm{S} & = 0.
+\end{align}
+
+In ``coupled'' mode, the time-averaged values of $\Theta_\textrm{BL}$, $S_\textrm{BL}$,
+$\gamma_\Theta$ and $\gamma_S$ are computed in MPAS-Ocean, and the fluxes are computed
+in the coupler.
+
+In ``standalone'' mode, the boundary conditions are solved and the fluxes computed in 
+MPAS-Ocean.  Three flux formulations are supported, ``isomip'', ``jenkins'' and 
+``hollandJenkins'', each with its own definition of the freezing potential temperature
+and the transfer velocities.
+
+\hfill \break \noindent \textit{isomip:}
+
+\noindent The ISOMIP formulation \citep{Hunter2006} is the simplest, using the 
+boundary-layer salinity to compute the freezing potential temperature and a 
+velocity independent heat-transfer velocity:
+\begin{align}
+  \Theta_f & = \lambda_1 S_\textrm{BL} + \lambda_2 + \lambda_3 p_b, \\
+  \gamma_\Theta & = \gamma_\textrm{ISO}.
+\end{align}
+The salt-transfer velocity $\gamma_S$ and the salinity at the boundary $S_b$
+are not needed for the flux computation and are not computed for this
+formulation.
+
+\hfill \break \noindent \textit{jenkins:}
+
+\noindent The \citet{Jenkins2010} boundary conditions are more sophisticated, 
+using the interface salinity in the freezing potential temperature 
+and including the spatially variable friction velocity in the computation of 
+heat and salt transfer across the boundary layer:
+\begin{align}
+  \Theta_f & = \lambda_1 S_b + \lambda_2 + \lambda_3 p_b, \\
+  \gamma_\Theta & = u_* \Gamma_\Theta, \\
+  \gamma_S & = u_* \Gamma_S,
+\end{align}
+where $\Gamma_\Theta$ and $\Gamma_S$ are constants calibrated from observations 
+\citep[e.g.][]{Jenkins2010}.
+
+\hfill \break \noindent \textit{holland-jenkins:}
+
+\noindent The \citet{Holland1999} formulation includes slightly nonlinear velocity 
+dependence in heat and salt transfer velocities, and is commonly used in many studies.  
+The boundary conditions are as in the ``jenkins'' case except that $\Gamma_\Theta$ and 
+$\Gamma_S$ are not constants, but are given by
+\begin{align}
+  \Gamma_{\Theta,S} & = \frac{1}{\Lambda_\textrm{turb} + \Lambda_\textrm{mol}^{\Theta,S}}, \\
+  \Lambda_\textrm{turb} & = \frac{1}{k} \textrm{ln}\left(\frac{u_* \xi_N}{f h_\nu}\right) + \frac{1}{2 \xi_N} - \frac{1}{k}, \\
+  \Lambda_\textrm{mol}^{\Theta,S} & = 12.5~(\textrm{Pr},\textrm{Sc})^{2/3} - 6, \\
+  h_\nu & = 5 \frac{\nu}{u_*},
+\end{align}
+where the various parameters $k$, $\xi_n$, $h_\nu$, $\textrm{Pr}$ and $\textrm{Sc}$ have the values defined 
+in \citet{Holland1999}.
+
+The sensible heat flux $\mathcal{F}_\textrm{H,ice}$ into the ice in 
+(\ref{ocean:\mode_land_ice_enthalpy_balance}) is not known in ``standalone'' mode.  This flux
+is generally small, with the dominant balance between latent heat released through melting
+and ocean sensible heat fluxes.  The default assumption is that 
+$\mathcal{F}_\textrm{H,ice} = 0$, meaning that the ice is perfectly insulating.  An alternative
+is to use the advection-diffusion method of \citet{Holland1999}, where the ice is assumed
+to advect vertically at the melt rate and its temperature is assumed
+to be at a reference surface temperature under melting conditions and at 
+the freezing point for freezing conditions.
+


### PR DESCRIPTION
This PR adds documentation for the land_ice_fluxes namelist to the user guide.

Note: several namelist variables' descriptions will need to be updated to match the documentation before the next release.  (I suspect this is true of many namelists.)
