### PR TITLE
Removed undefined reference in the visualization section.

### DIFF
--- a/users_guide/shared/mpas_visualization.tex
+++ b/users_guide/shared/mpas_visualization.tex
@@ -5,7 +5,7 @@
 \chapter{Visualization}
 \label{chap:mpas_visualization}
 
-This chapter discusses visualization tools that may be used by all cores.  For instructions on additional visualization tools for this core, see Chapter \ref{chap:\core_visualization}.
+This chapter discusses visualization tools that may be used by all cores.
 
 \section{ParaView}
 


### PR DESCRIPTION
The visualization section has a reference to a core specific visualization section. This presumes the existence of one, which the sea-ice core does not have. Also, its unclear even if we did how this would be set per core, since no mechanism seems to have been implemented for this.